### PR TITLE
docs: add ADR for changelog and versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+<!-- Versioning will be as follows:
+
+0.1.0 → error pipeline end-to-end 
+0.2.0 → performance capture
+0.3.0 → feedback widgets
+0.4.0 → notifications + build signals -->
+
 ## [Unreleased]
 
 ### Added
@@ -12,9 +19,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Project Primer (`docs/PROJECT-PRIMER.md`) covering architecture, sub-teams, working agreements, and glossary.
 - Design Brief (`docs/DESIGN-BRIEF.md`) covering MVP and target users.
 - Sprint 1 overview (`docs/sprints/sprint-1-overview.md`).
+- Sprint 2 overview (`docs/sprints/sprint-2-overview.md`).
+- ADR index and scaffolding (`docs/adr/`).
+- Pull request template (`.github/PULL_REQUEST_TEMPLATE.md`).
+- Linting setup with ESLint + ADR.
+- Playwright E2E foundation.
+- SDK API design document defining the public surface of `watchtower.init(...)` and related methods.
+- SDK Distribution ADR — npm with `github:` install for development, structured npm releases for production.
+- Infrastructure ADR — Cloudflare Workers backend with D1.
+- Testing Frameworks ADR — Vitest for Backend, node:test for SDK and Dashboard, Playwright for E2E.
+- cse135.site research note.
+- Ingestion contract between SDK and Backend (`docs/contracts/ingestion.md`).
+- Dashboard wireframes for core views and notification configuration (`docs/wireframes/`).
+- Dashboard API requirements document (`docs/dashboard-api-needs.md`).
 
 ### Changed
--
+- API endpoints were changed from 3 to 1? (double check with backend & sdk teams to make sure)
 
 ### Deprecated
 -
@@ -30,5 +50,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-*Versions will be tagged starting at `0.1.0` once the first MVP-relevant feature lands.*
-*See [docs/adr/index.md](docs/adr/index.md) for the ADR governing our versioning policy (forthcoming).*
+*Versions will be tagged starting at `0.1.0` once the first MVP-relevant feature (error pipeline) lands.*
+*See [docs/adr/index.md](docs/adr/index.md) for the ADR governing our versioning policy.*

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 > A lightweight observability tool for developers. Catch errors, surface performance issues, and collect user feedback — without the noise.
 
-<!-- Badges go here once CI is set up -->
-<!-- ![CI](https://github.com/cse110-sp26-group06/watchtower/actions/workflows/ci.yml/badge.svg) -->
-
 ## About
 
 WatchTower is a small observability platform: developers add an injectable JavaScript SDK to their site, and WatchTower captures runtime errors, performance metrics, and user feedback, surfacing them through a centralized dashboard. Think Sentry or LogRocket, but small enough that one person can understand the whole thing end to end.

--- a/docs/PROJECT-PRIMER.md
+++ b/docs/PROJECT-PRIMER.md
@@ -155,7 +155,7 @@ Commit messages follow the [Conventional Commits](https://www.conventionalcommit
 - `test(backend): add ingestion endpoint coverage`
 - `refactor(dashboard): extract chart rendering into module`
 
-Consistent commit messages give us readable history, and they unlock the option to generate a changelog automatically later if we want to.
+Consistent commit messages keep history readable and leave the door open for automation if the team ever revisits the changelog/versioning decision.
 
 ### Linting and the question of pre-commit hooks
 
@@ -172,15 +172,13 @@ For now: run `npm run lint` locally before pushing. We'll revisit pre-commit hoo
 
 ### Changelog
 
-We will maintain a `CHANGELOG.md` file at the repo root, following the [Keep a Changelog](https://keepachangelog.com/) format. Every release bumps the SemVer version and adds a corresponding section to the changelog.
+We maintain a `CHANGELOG.md` file at the repo root, following the [Keep a Changelog](https://keepachangelog.com/) format.
 
-There are three ways teams typically maintain a changelog, and we'll pick one in an ADR:
+WatchTower uses **unified Semantic Versioning** for the whole repo: one `v0.x.y` version per release, shared across the SDK, Backend, and Dashboard. The SDK's published package version should mirror the repo version.
 
-- **Manual:** A developer edits `CHANGELOG.md` by hand in the same PR that bumps the version. Simple, full editorial control, easy to forget.
-- **Fully automated:** A tool like `release-please` or `standard-version` reads the Conventional Commits since the last release and generates the changelog automatically. Less work per release, but the output reflects raw commit history rather than user-facing impact.
-- **Hybrid:** A tool generates a draft, then a human edits it before release. Tools like `changesets` support this — developers add a small description file when they make a meaningful PR, and the tool aggregates them at release time.
+For this project, changelog maintenance is **manual**. At release time, a developer updates `CHANGELOG.md` in the same PR that bumps the version. This keeps the process simple and avoids depending on perfect Conventional Commit discipline or extra release automation.
 
-Manual works fine for a 10-week course project shipping a handful of releases. Automation pays off more for projects releasing weekly to real users. We'll start with whichever the team agrees on in our ADR and revisit if it's not working.
+See [ADR 0005](adr/0005-changelog-and-versioning.md) for the rationale.
 
 ### GenAI usage must be disclosed
 

--- a/docs/adr/0005-changelog-and-versioning.md
+++ b/docs/adr/0005-changelog-and-versioning.md
@@ -1,0 +1,51 @@
+# Pick Versioning and Changelog Approach
+
+## Status
+
+- [ ] Pending
+- [ ] Rejected
+- [x] Accepted
+
+## Context and Problem Statement
+
+The project spec requires using SemVer and maintaining a changelog (manual, automated, or hybrid). We need a versioning strategy and changelog approach that fits how we actually release.
+
+## Decision Drivers
+
+- Simplicity for a single-team, short-timeline project
+- Spec compliance: SemVer + maintained changelog
+- Resilience against imperfect commit-message discipline (Conventional Commits are encouraged but maybe not consistent in practice)
+- Minimal CI and setup overhead
+
+## Considered Options
+
+**Versioning**
+- Per-deliverable SemVer (e.g. `sdk@0.3.1`, `backend@0.5.0`), each component versioned independently
+- Unified SemVer — one `v0.x.y` for the repo, all three components advance together
+
+**Changelog**
+- Manual — team writes entries at release time
+- Automated — tools like release-please or semantic-release generate entries from Conventional Commits
+- Hybrid — auto-generate, then manually curate before release
+
+## Decision Outcome
+
+**Versioning: unified.** One `v0.x.y` tag per release on the repo. The SDK's `package.json` version mirrors the project tag so external consumers (npm) see a SemVer-meaningful version. Backend and Dashboard don't have external consumers, so independent versions would add bookkeeping for no benefit. The versioning scheme will be as follows:
+
+0.1.0 → error pipeline end-to-end 
+0.2.0 → performance capture
+0.3.0 → feedback widgets
+0.4.0 → notifications + build signals
+
+**Changelog: manual.** Entries added to `CHANGELOG.md` at release time, using the Keep a Changelog format already scaffolded in Sprint 1. Releases align with sprint ends, so changelog updates happen roughly once a week.
+
+### Pros
+- No setup cost, no tool dependency, no additional CI to maintain
+- Doesn't rely on commit messages being perfectly formatted, entries are written from a release-time review of what shipped
+- Aligns with the team's actual release pattern (the three components ship together, not independently)
+- Keep a Changelog scaffolding already exists in the repo from Sprint 1
+- SDK consumers see a meaningful version via the unified tag flowing into the SDK package
+
+### Cons
+- If a component ever needs an independent release (e.g. patching the SDK without bumping the others), we'd need to revisit this decision
+- Manual changelog relies on discipline at release time — if it's forgotten, it's worse than automated would have been

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -29,6 +29,8 @@ Each ADR carries one of the following statuses:
 | 0001 | [SDK distribution method](0001-sdk-distribution-method.md) | Accepted | 2026-05-11 |
 | 0002 | [Backend infrastructure](0002-backend-infrastructure.md) | Accepted | 2026-05-11 |
 | 0003 | [Testing framework](0003-testing-framework.md) | Accepted | 2026-05-11 |
+| 0004 | [Linting framework](0004-linting-framework.md) | Accepted | 2026-05-13 |
+| 0005 | [Changelog and versioning approach](0005-changelog-and-versioning.md) | Accepted | 2026-05-15 |
 
 ## Adding a New ADR
 


### PR DESCRIPTION
# Info

Closes #22. 

# Description

Created an ADR for changelog and versioning approach

## Changes

- Adjusted PROJECT-PRIMER.md to update this choice
- Removed badge from README.md (unrelated)
- Updated ADR index

## AI Use Log

Utilized Claude to draft the ADR, made adjustments by hand

# Type of Change

- [ ] Patch (non-breaking change/bugfix)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to not work as
      expected)
- [x] Documentation (A change to a README/description/docs)
- [ ] Continuous Integration/DevOps Change (Related to deployment steps, continuous integration
      workflows, linting, etc.)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

If you've selected Patch, Minor, or Major as your change type, **make sure to bump the version before merging in `package.json`!**
# Testing

I have tested that my changes fully resolve the linked issue ...

- [ ] locally.
- [ ] on the testing API/testing database.

# Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have followed the style guidelines of this project.
- [ ] My changes produce no new warnings.

# Definition of Done(DoD): you have checked that

- [ ] Code works and is committed
- [ ] Tests added (unit and/or E2E as appropriate) and passing
- [ ] JSDoc on any new public surfaces
- [ ] Linting passes locally and in CI
- [ ] Docs updated (README, Wiki, this primer if relevant)
- [ ] Commit messages follow Conventional Commits
- [ ] PR description discloses any AI usage
- [ ] If >300 LoC: reviewed by another human team member
- [ ] Issue moved to Done on the project board

# Screenshots

Please include screenshots of any relevant changes, if applicable.
