### PR TITLE
finished implementing BE2 and BE4

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -14,7 +14,11 @@ CREATE TABLE IF NOT EXISTS errors (
     error_type TEXT,
     severity TEXT NOT NULL DEFAULT 'error',
 
-    stack_trace_json TEXT NOT NULL,
+    stack_trace TEXT NOT NULL,
+    file TEXT NOT NULL,
+    lineno INTEGER NOT NULL,
+    colno INTEGER NOT NULL,
+
     payload_json TEXT NOT NULL,
 
     client_timestamp TEXT NOT NULL,
@@ -31,3 +35,11 @@ ON errors (status);
 
 CREATE INDEX IF NOT EXISTS idx_errors_severity
 ON errors (severity);
+
+-- This is the authentication table which stores the authentication key for each 
+CREATE TABLE IF NOT EXISTS projects (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    api_key TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL
+);

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,4 +1,5 @@
 import { handleIngest } from "./routes/ingest.js";
+import { generateApiKey } from './middleware/auth.js';
 
 export default {
   async fetch(request, env) {
@@ -13,6 +14,28 @@ export default {
       });
     }
 
+    // 
+    // Project creation — generates and stores a new API key
+    if (path === '/api/key_generate' && request.method === 'POST') {
+    let body;
+    try {
+      body = await request.json();
+    } catch {
+      return jsonResponse({ status: 'error', message: 'Invalid JSON' }, 400);
+    }
+
+    if (!body.name) {
+      return jsonResponse({ status: 'error', message: 'Project name required' }, 400);
+    }
+
+    try {
+      const key = await generateApiKey(env, body.name);
+        return jsonResponse({ status: 'ok', project_id: key.id, api_key: key.api_key,}, 201);
+    } catch (err) {
+    console.error('Failed to create project:', err);
+    return jsonResponse({ status: 'error', message: 'Failed to create project' }, 500);
+  }
+}
     // Ingestion routes
     if (path.startsWith("/ingest/") && request.method === "POST") {
       return handleIngest(request, env, path);
@@ -20,6 +43,7 @@ export default {
 
     // Read API routes (BE-5 adds these)
     // if (path.startsWith("/api/")) { ... }
+
 
     return jsonResponse({ status: "error", message: "Not found" }, 404);
   },

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,3 +1,4 @@
+/* global console */
 import { handleIngest } from "./routes/ingest.js";
 import { generateApiKey } from './middleware/auth.js';
 

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,3 +1,4 @@
+/* global crypto */
 /**
  * Authentication middleware for WatchTower Backend
  * Handles API key generation and validation

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,2 +1,38 @@
-// BE-4: API key authentication
-// TODO: replace hardcoded keys in ingest.js with D1 lookup
+/**
+ * Authentication middleware for WatchTower Backend
+ * Handles API key generation and validation
+ */
+
+/**
+ * Generates a unique API key and stores it in D1 projects table
+ * @param {object} env - Cloudflare env with D1 binding
+ * @param {string} name - project name
+ * @returns {object} - project record with generated api_key
+ */
+export async function generateApiKey(env, name) {
+  const id = crypto.randomUUID();
+  const api_key = 'wt_' + crypto.randomUUID().replace(/-/g, '');
+  const created_at = new Date().toISOString();
+
+  await env.watchtower_db.prepare(
+    'INSERT INTO projects (id, name, api_key, created_at) VALUES (?, ?, ?, ?)'
+  ).bind(id, name, api_key, created_at).run();
+
+  return { id, name, api_key, created_at };
+}
+
+/**
+ * Validates an API key against the projects table in D1
+ * @param {object} env - Cloudflare env with D1 binding
+ * @param {string} api_key - the API key to validate
+ * @returns {object|null} - project record if valid, null if invalid
+ */
+export async function validateApiKey(env, api_key) {
+  if (!api_key) return null;
+
+  const project = await env.watchtower_db.prepare(
+    'SELECT * FROM projects WHERE api_key = ?'
+  ).bind(api_key).first();
+
+  return project || null;
+}

--- a/backend/src/routes/ingest.js
+++ b/backend/src/routes/ingest.js
@@ -1,19 +1,28 @@
-import { jsonResponse } from "../index.js";
+import { jsonResponse } from '../index.js'; // imported function which is convenient for consistent response return
+import { storeError } from '../storage/d1.js'; // imported function from d1, link to d1.js
+import { validateApiKey } from '../middleware/auth.js';
 
-const VALID_ENDPOINTS = ["/ingest/error", "/ingest/log", "/ingest/performance"];
+const VALID_ENDPOINTS = ['/ingest/error', '/ingest/log', '/ingest/performance'];
 const REQUIRED_PAYLOAD_FIELDS = {
-  "/ingest/error": ["message", "stack_trace"],
-  "/ingest/log": ["message", "level", "timestamp"],
-  "/ingest/performance": ["name", "start_timestamp", "end_timestamp", "duration_ms"],
-}
+  // added all properties in event except for severity, will add it after sdk implements it
+  '/ingest/error': ['message', 'type', 'stack_trace', 'file', 'lineno', 'colno'],
+  '/ingest/log': ['message', 'level', 'timestamp'],
+  '/ingest/performance': ['name', 'start_timestamp', 'end_timestamp', 'duration_ms'],
+};
 
 // Hardcoded keys for now — BE-4 replaces with D1 lookup
-const API_KEYS = ["client1", "client2", "client3"];
 
+
+/**
+ * Handles all ingest POST requests from the SDK
+ * @param {Request} request - incoming request
+ * @param {object} env - Cloudflare env with D1 binding
+ * @param {string} path - the endpoint path
+ */
 export async function handleIngest(request, env, path) {
   // Validate endpoint
   if (!VALID_ENDPOINTS.includes(path)) {
-    return jsonResponse({ status: "error", message: "Not found" }, 404);
+    return jsonResponse({ status: 'error', message: 'Not found' }, 404);
   }
 
   // Parse JSON body
@@ -21,53 +30,71 @@ export async function handleIngest(request, env, path) {
   try {
     data = await request.json();
   } catch {
-    return jsonResponse({ status: "error", message: "Invalid JSON" }, 400);
+    return jsonResponse({ status: 'error', message: 'Invalid JSON' }, 400);
   }
 
   // Validate API key
-  if (!data.api_key || !API_KEYS.includes(data.api_key)) {
-    return jsonResponse({ status: "error", message: "Invalid API key" }, 401);
-  }
+const checkAPI = await validateApiKey(env, data.api_key);
+if (!checkAPI) {
+  return jsonResponse({ status: 'error', message: 'Invalid API key' }, 401);
+}
 
   // Validate required envelope fields
   if (!data.service || !data.environment) {
-    return jsonResponse({ status: "error", message: "Missing required fields" }, 400);
+    return jsonResponse({ status: 'error', message: 'Missing required fields' }, 400);
   }
 
+  // Validate events array
   if (!data.events || data.events.length === 0) {
-    return jsonResponse({ status: "error", message: "No events" }, 400);
+    return jsonResponse({ status: 'error', message: 'No events' }, 400);
   }
 
-
-  for(const event of data.events){
-    if(!event.timestamp || !event.payload || !event.event_type){
-      return jsonResponse({ status: "error", message: "Invalid event format" }, 400);
+  // Loop 1 — validate all events before storing anything
+  for (const event of data.events) {
+    if (!event.timestamp || !event.payload || !event.event_type) {
+      return jsonResponse({ status: 'error', message: 'Invalid event format' }, 400);
     }
-    // Validate required event payload fields based on endpoint
+
+    // Validate required payload fields per endpoint
     const requiredFields = REQUIRED_PAYLOAD_FIELDS[path];
     for (const field of requiredFields) {
       if (event.payload[field] === undefined || event.payload[field] === null) {
-        return jsonResponse({ status: "error", message: `Missing required event payload field: ${field}` }, 400);
+        return jsonResponse({ status: 'error', message: `Missing required event payload field: ${field}` }, 400);
       }
     }
-    
   }
 
-
-
-  // Process events — BE-3 wires this to D1
+  // Loop 2 — build record and store each event in D1
   const server_timestamp = new Date().toISOString();
   for (const event of data.events) {
-    const record = {
-      ...event,
-      api_key: data.api_key,
-      service: data.service,
-      environment: data.environment,
-      server_timestamp,
-    };
-    console.log(`[${path}]`, record);
-    // TODO: env.DB.prepare(...).bind(...).run()
+    try {
+      if (path === '/ingest/error') {
+        const record = {
+          id: crypto.randomUUID(), // generates random and unique id for the event
+          api_key: data.api_key,
+          service: data.service,
+          environment: data.environment,
+          message: event.payload.message,
+          error_type: event.payload.type || null,
+          severity: event.payload.severity || 'error', // set to error for null case as it is not implemented yet
+          stack_trace: event.payload.stack_trace,
+          file: event.payload.file,        
+          lineno: event.payload.lineno,    
+          colno: event.payload.colno,      
+          payload_json: JSON.stringify(event.payload),
+          client_timestamp: event.timestamp,
+          server_timestamp,
+          status: 'unresolved',
+        };
+        // we send this bounded data to
+        await storeError(env, record);
+      }
+      // storeLog and storePerformance added once Ethan adds tables
+    } catch (err) {
+      console.error('D1 write failed:', err);
+      return jsonResponse({ status: 'error', message: 'Storage error' }, 500);
+    }
   }
 
-  return jsonResponse({ status: "ok" }, 200);
+  return jsonResponse({ status: 'ok' }, 200);
 }

--- a/backend/src/routes/ingest.js
+++ b/backend/src/routes/ingest.js
@@ -1,3 +1,4 @@
+/* global crypto, console */
 import { jsonResponse } from '../index.js'; // imported function which is convenient for consistent response return
 import { storeError } from '../storage/d1.js'; // imported function from d1, link to d1.js
 import { validateApiKey } from '../middleware/auth.js';

--- a/backend/src/storage/d1.js
+++ b/backend/src/storage/d1.js
@@ -1,2 +1,25 @@
 // BE-3: D1 storage layer
 // TODO: implement write and read functions for events
+
+export async function storeError(env, record) {
+  await env.watchtower_db.prepare(`
+    INSERT INTO errors (id, api_key, service, environment, message, error_type, severity, stack_trace, file, lineno, colno, payload_json, client_timestamp, server_timestamp, status)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).bind(
+    record.id,
+    record.api_key,
+    record.service,
+    record.environment,
+    record.message,
+    record.error_type,
+    record.severity,
+    record.stack_trace,
+    record.file,
+    record.lineno,
+    record.colno,
+    record.payload_json,
+    record.client_timestamp,
+    record.server_timestamp,
+    record.status
+  ).run();
+}

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -1,3 +1,4 @@
+account_id = "0340d648cb394b95228857ffd4c6f1b9"
 name = "watchtower-backend"
 main = "src/index.js"
 compatibility_date = "2026-05-12"


### PR DESCRIPTION
# Info

Closes #60 #61 .

# Description

What changes did you make? List all distinct problems that this PR addresses. Explain any relevant
motivation or context.

BE-2 is done and now our backend system receives any post request through url https://watchtower-backend.group6.workers.dev/ingest/error, when it is in right format and authentication remotely and stores in D1 server in a right format. The example of right post format is 
curl -X POST https://watchtower-backend.group6.workers.dev/ingest/error \
  -H 'Content-Type: application/json' \
  -d '{
    "api_key": "wt_e5432da49ac342e6979f901324dae034",
    "service": "my-app",
    "environment": "production",
    "events": [
      {
        "event_type": "error",
        "timestamp": "2026-05-16T03:00:00Z",
        "payload": {
          "message": "TypeError crashed",
          "type": "TypeError",
          "stack_trace": "TypeError at app.js:42",
          "file": "app.js",
          "lineno": 42,
          "colno": 15
        }
      }
    ]
  }'

then it will send 200 ok.
As sdk team is working on severity right now, it is automatically saved as "error", and will be updated later when sdk finishes on it.
Plus, as the SDK team has changed the label from stack_trace_json to stack_trace, we needed to change the whole schema, and felt importance of documentation. I think dashboard team did not change their schema according to this. 

The BE-4 is now done and now when dashboard team gets account generation request, it can send a post requesting for the api key generation, and we will respond with the status, project id, and api_key, Here the api key should be given to the user and the user should input this key in order to be authorized for posting the information to the server. The authentication key for user viewing the dataset on dashboard should be later discussed. This api key is stored inside the d1 server in separate table and this will be used to check api key sent from npm library.

The example format of post for auth-key generation
curl -X POST https://watchtower-backend.group6.workers.dev/api/key_generate \
  -H 'Content-Type: application/json' \
  -d '{"name": "my-app"}'
{"status":"ok","project_id":"4181bde9-163e-4cd2-b637-7e7703edeb48","api_key":"wt_e5432da49ac342e6979f901324dae034"}
I haven't done any tests yet, but will do later on after we show our work to dashboard team
## Changes

Stated above

## AI Use Log

I used Claude sonnet 4.6 in order to learn how to create tables in sql schema, how to apply the sql structure we built on the actual d1 server, how to deploy the server with change. For the coding, I used Claude in order to get support how to generate the random but unique api keys and event id, and learned using export functions is the easy way to link the js codes together. I got assessed with binding the whole information before actually pushing it into the server.

# Type of Change

- [x] Patch (non-breaking change/bugfix)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (A change to a README/description/docs)
- [ ] Continuous Integration/DevOps Change (Related to deployment steps, continuous integration
      workflows, linting, etc.)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

If you've selected Patch, Minor, or Major as your change type, **make sure to bump the version before merging in `package.json`!**
# Testing

I have tested that my changes fully resolve the linked issue ...

- [ ] locally.
- [ ] on the testing API/testing database.

# Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have followed the style guidelines of this project.
- [ ] My changes produce no new warnings.

# Definition of Done(DoD): you have checked that

- [x] Code works and is committed
- [ ] Tests added (unit and/or E2E as appropriate) and passing
- [ ] JSDoc on any new public surfaces
- [ ] Linting passes locally and in CI
- [ ] Docs updated (README, Wiki, this primer if relevant)
- [ ] Commit messages follow Conventional Commits
- [ ] PR description discloses any AI usage
- [ ] If >300 LoC: reviewed by another human team member
- [ ] Issue moved to Done on the project board

# Screenshots

<img width="1800" height="1169" alt="Screenshot 2026-05-15 at 9 23 21 PM" src="https://github.com/user-attachments/assets/a17e0192-118d-4f14-86f4-94b0276f961d" />

