### PR TITLE
feat: dashboard api client module

### DIFF
--- a/dashboard/error-list.html
+++ b/dashboard/error-list.html
@@ -46,7 +46,7 @@
           <select id="filter-time" class="filter-select">
             <option value="24h">Last 24h</option>
             <option value="7d">Last 7 days</option>
-            <option value="30d">Last 30 days</option>
+            <option value="30d" selected>Last 30 days</option>
           </select>
         </div>
         <div class="filter-group">
@@ -60,6 +60,12 @@
       </section>
 
       <section id="error-list" class="error-list" aria-label="Error entries" aria-live="polite"></section>
+
+      <div id="pagination" style="display:none;">
+        <button id="prevBtn" class="btn btn--outline">← Prev</button>
+        <span id="pageInfo"></span>
+        <button id="nextBtn" class="btn btn--outline">Next →</button>
+      </div>
     </main>
 
     <div id="toast"></div>

--- a/dashboard/scripts/api/api.js
+++ b/dashboard/scripts/api/api.js
@@ -1,29 +1,33 @@
 // api.js
 // DASH-3: Centralized API client for WatchTower dashboard read endpoints.
-// Handles auth (X-Api-Key), network failures, 4xx, and 5xx error states.
-// All other api/* modules must go through apiGet() — never call fetch() directly.
+// Handles auth (api_key query param), network failures, 4xx, and 5xx error states.
+// All other modules must go through apiGet() — never call fetch() directly.
+//
+// Auth note: X-Api-Key header is NOT used — backend CORS only allows
+// Content-Type as a custom header. Auth is injected as api_key query param.
 
-import { API_BASE } from '../utils/constants.js';
+import { API_BASE, API_KEY } from '../utils/constants.js';
 
 // ─── Auth ─────────────────────────────────────────────────────────────────────
 
 /**
- * Retrieves the WatchTower API key.
- * Swap implementation to pull from a meta tag, config object, or env injection.
+ * Retrieves the WatchTower API key from constants.
+ * Swap for runtime injection (meta tag, config object) when multi-project
+ * support is needed.
  * @returns {string | null}
  */
 function getApiKey() {
-  return window.__WATCHTOWER_API_KEY__ ?? null;
+  return API_KEY ?? null;
 }
 
 // ─── Core Fetch Wrapper ───────────────────────────────────────────────────────
 
 /**
- * Central fetch wrapper. Attaches auth headers and normalizes all error states.
+ * Central fetch wrapper. Normalizes all error states into a consistent shape.
  *
  * Returns one of two shapes — callers must always check `success`:
- *   { success: true,  data:  any       }
- *   { success: false, error: ApiError  }
+ *   { success: true,  data:  any      }
+ *   { success: false, error: ApiError }
  *
  * @typedef {"network"|"client"|"server"} ErrorType
  * @typedef {{ type: ErrorType, status?: number, message: string }} ApiError
@@ -33,12 +37,9 @@ function getApiKey() {
  * @returns {Promise<{ success: boolean, data?: any, error?: ApiError }>}
  */
 async function apiFetch(url, options = {}) {
-  const apiKey = getApiKey();
-
   const headers = {
     "Accept": "application/json",
     "Content-Type": "application/json",
-    ...(apiKey ? { "X-Api-Key": apiKey } : {}),
     ...(options.headers ?? {}),
   };
 
@@ -123,14 +124,21 @@ async function apiFetch(url, options = {}) {
 
 /**
  * Perform a GET request to a WatchTower read endpoint.
- * Params are appended as a query string via URLSearchParams.
+ * api_key is automatically injected as a query param on every request.
+ * Additional params are merged alongside it.
  *
- * @param {string}              endpoint - Path relative to API_BASE (e.g. "/errors")
- * @param {Record<string,string>} [params] - Query parameters
+ * @param {string}                  [endpoint] - Path appended to API_BASE (e.g. '' or '/stats')
+ * @param {Record<string, string>}  [params]   - Additional query parameters
  * @returns {Promise<{ success: boolean, data?: any, error?: ApiError }>}
  */
-async function apiGet(endpoint, params = {}) {
-  const query = new URLSearchParams(params).toString();
+async function apiGet(endpoint = '', params = {}) {
+  const apiKey = getApiKey();
+
+  const query = new URLSearchParams({
+    ...(apiKey ? { api_key: apiKey } : {}),
+    ...params,
+  }).toString();
+
   const url = query
     ? `${API_BASE}${endpoint}?${query}`
     : `${API_BASE}${endpoint}`;

--- a/dashboard/scripts/api/api.js
+++ b/dashboard/scripts/api/api.js
@@ -123,6 +123,19 @@ async function apiFetch(url, options = {}) {
 // ─── Public Interface ─────────────────────────────────────────────────────────
 
 /**
+ * Make an authenticated PATCH request to the backend.
+ * @param {string} endpoint
+ * @param {object} body
+ * @returns {Promise<{success: true, data: any} | {success: false, error: object}>}
+ */
+export async function apiPatch(endpoint, body = {}) {
+  return apiFetch(endpoint, {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+}
+
+/**
  * Perform a GET request to a WatchTower read endpoint.
  * api_key is automatically injected as a query param on every request.
  * Additional params are merged alongside it.

--- a/dashboard/scripts/pages/errorDetail/errorDetail.js
+++ b/dashboard/scripts/pages/errorDetail/errorDetail.js
@@ -10,6 +10,7 @@ import { renderNavbar }     from '../../components/navbar.js';
 import { badgeClass }       from '../../components/errorCard.js';
 import { renderStackTrace } from './stackTrace.js';
 import { MOCK_ERRORS, normalizeError } from '../../utils/constants.js';
+import { apiGet } from '../../api/api.js';
 import { requireAuth } from '../../utils/auth.js';
 import { escHtml }          from '../../utils/dom.js';
 import { markErrorResolved, withResolvedStatus } from '../../utils/errorStatus.js';
@@ -59,11 +60,10 @@ async function handleResolve() {
     }
     // ── END MOCK ─────────────────────────────────────────────────
 
-    const res = await fetch(`/api/errors/${encodeURIComponent(errorId)}`, {
-      method:  'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body:    JSON.stringify({ status: 'resolved' }),
-    });
+  const res = await fetch(
+    `https://watchtower-backend.group6.workers.dev/api/errors/${encodeURIComponent(errorId)}?api_key=wt_e5432da49ac342e6979f901324dae034`,
+    { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ status: 'resolved' }) }
+  );
     if (!res.ok) {throw new Error(`HTTP ${res.status} — ${res.statusText}`);}
 
     syncResolveButton(true);
@@ -99,14 +99,15 @@ async function fetchError(id) {
     if (!raw) {throw new Error(`No error found with id "${id}"`);}
     return withResolvedStatus(normalizeError(raw));
   }
-  // ── END MOCK ─────────────────────────────────────────────────
 
-  const res = await fetch(`/api/errors/${encodeURIComponent(id)}`, {
-    headers: { Accept: 'application/json' },
-  });
-  if (!res.ok) {throw new Error(`HTTP ${res.status} — ${res.statusText}`);}
-  return withResolvedStatus(normalizeError(await res.json()));
+  const result = await apiGet('', { status: 'all' });
+  if (!result.success) {throw new Error(result.error.message);}
+  const errors = result.data?.errors ?? [];
+  const row = errors.find(e => String(e.id) === String(id));
+  if (!row) {throw new Error('No error found with that ID.');}
+  return withResolvedStatus(normalizeError(row));
 }
+
 
 /* ── Timeline icon ──────────────────────────────────────────────── */
 /**
@@ -173,10 +174,11 @@ function renderDetail(err) {
     </section>` : '';
 
   // Stack trace
-  const stack = err.stackTrace?.length ? `
+  const stackFrames = err.stackTrace ? [err.stackTrace] : [];
+  const stack = stackFrames.length ? `
     <section class="detail-section" aria-labelledby="stack-heading">
       <h2 class="detail-section__title" id="stack-heading">Stack Trace</h2>
-      ${renderStackTrace(err.stackTrace)}
+      ${renderStackTrace(stackFrames)}
     </section>` : '';
 
   // Event timeline

--- a/dashboard/scripts/pages/errorDetail/errorDetail.js
+++ b/dashboard/scripts/pages/errorDetail/errorDetail.js
@@ -10,7 +10,7 @@ import { renderNavbar }     from '../../components/navbar.js';
 import { badgeClass }       from '../../components/errorCard.js';
 import { renderStackTrace } from './stackTrace.js';
 import { MOCK_ERRORS, normalizeError } from '../../utils/constants.js';
-import { apiGet } from '../../api/api.js';
+import { apiGet, apiPatch } from '../../api/api.js';
 import { requireAuth } from '../../utils/auth.js';
 import { escHtml }          from '../../utils/dom.js';
 import { markErrorResolved, withResolvedStatus } from '../../utils/errorStatus.js';
@@ -60,11 +60,8 @@ async function handleResolve() {
     }
     // ── END MOCK ─────────────────────────────────────────────────
 
-  const res = await fetch(
-    `https://watchtower-backend.group6.workers.dev/api/errors/${encodeURIComponent(errorId)}?api_key=wt_e5432da49ac342e6979f901324dae034`,
-    { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ status: 'resolved' }) }
-  );
-    if (!res.ok) {throw new Error(`HTTP ${res.status} — ${res.statusText}`);}
+    const result = await apiPatch(`/${errorId}`, { status: 'resolved' });
+    if (!result.success) throw new Error(result.error.message);
 
     syncResolveButton(true);
     showToast('Error marked as resolved.');

--- a/dashboard/scripts/pages/errorList/errorFilter.js
+++ b/dashboard/scripts/pages/errorList/errorFilter.js
@@ -52,7 +52,6 @@ export function buildUrl(state) {
 
   const sinceIso = sinceToIso(state.since);
   if (sinceIso) { params.set('since', sinceIso); }
-	//if (state.severity && state.severity !== 'all') {params.set('severity', state.severity);}
   if (state.status && state.status !== 'all') { params.set('status', state.status); }
 
   return `${API_BASE}?${params}`;

--- a/dashboard/scripts/pages/errorList/errorFilter.js
+++ b/dashboard/scripts/pages/errorList/errorFilter.js
@@ -6,7 +6,7 @@
  * means the main file only deals with fetching and rendering.
  */
 
-import { API_BASE, PAGE_LIMIT } from '../../utils/constants.js';
+import { API_BASE, API_KEY, PAGE_LIMIT } from '../../utils/constants.js';
 
 /**
  * Converts a `since` shorthand (e.g. '24h', '7d') into an ISO 8601
@@ -20,11 +20,11 @@ import { API_BASE, PAGE_LIMIT } from '../../utils/constants.js';
  * @returns {string|null} ISO timestamp string, or null when since === 'all'
  */
 export function sinceToIso(since) {
-  if (!since || since === 'all') {return null;}
+  if (!since || since === 'all') { return null; }
 
   const units = { h: 60 * 60 * 1000, d: 24 * 60 * 60 * 1000 };
   const match = since.match(/^(\d+)([hd])$/);
-  if (!match) {return null;}
+  if (!match) { return null; }
 
   const ms = parseInt(match[1], 10) * units[match[2]];
   return new Date(Date.now() - ms).toISOString();
@@ -34,29 +34,26 @@ export function sinceToIso(since) {
  * Builds the API query URL from the current state.
  *
  * Param mapping → D1 column:
+ *   api_key  → authenticates and scopes results to the right project
  *   since    → server_timestamp  (ISO string; backend does `>= ?`)
- *   severity → severity
+ *   severity → severity          
  *   status   → status
  *   page / limit → handled in the Worker for LIMIT / OFFSET
- *
- * Removed: `projectId` (no project_id column in D1 schema).
- * The API key used to authenticate the request implicitly scopes results
- * to the right project on the backend.
  *
  * @param {object} state
  * @returns {string}
  */
 export function buildUrl(state) {
   const params = new URLSearchParams({
-    page:  state.page,
-    limit: PAGE_LIMIT,
+    api_key: API_KEY,
+    page:    state.page,
+    limit:   PAGE_LIMIT,
   });
 
   const sinceIso = sinceToIso(state.since);
-  if (sinceIso) {params.set('since', sinceIso);}
-
-  if (state.severity && state.severity !== 'all') {params.set('severity', state.severity);}
-  if (state.status   && state.status   !== 'all') {params.set('status',   state.status);}
+  if (sinceIso) { params.set('since', sinceIso); }
+	//if (state.severity && state.severity !== 'all') {params.set('severity', state.severity);}
+  if (state.status && state.status !== 'all') { params.set('status', state.status); }
 
   return `${API_BASE}?${params}`;
 }

--- a/dashboard/scripts/pages/errorList/errorList.js
+++ b/dashboard/scripts/pages/errorList/errorList.js
@@ -1,16 +1,21 @@
-import { renderNavbar }    from '../../components/navbar.js';
-import { renderErrorCard } from '../../components/errorCard.js';
-import { showToast }       from '../../utils/toast.js';
+import { renderNavbar }              from '../../components/navbar.js';
+import { renderErrorCard }           from '../../components/errorCard.js';
+import { showToast }                 from '../../utils/toast.js';
 import { MOCK_ERRORS, PAGE_LIMIT, normalizeError } from '../../utils/constants.js';
-import { requireAuth } from '../../utils/auth.js';
-import { withResolvedStatuses } from '../../utils/errorStatus.js';
-import { buildUrl, initFilters }   from './errorFilter.js';
+import { requireAuth }               from '../../utils/auth.js';
+import { withResolvedStatuses }      from '../../utils/errorStatus.js';
+import { initFilters, sinceToIso }   from './errorFilter.js';
+import { apiGet }                    from '../../api/api.js';
 
 const session = requireAuth();
-if (session) {renderNavbar('error-list');}
+if (session) { renderNavbar('error-list'); }
+
+// Expose load() to window so onclick="load()" in renderFetchError works
+// ES modules are scoped and don't attach to window automatically
+window.load = load;
 
 /* ── State ──────────────────────────────────────────────────── */
-const state = { severity: '', since: '24h', status: 'unresolved', page: 1, total: 0, loading: false };
+const state = { severity: '', since: '30d', status: 'unresolved', page: 1, total: 0, loading: false };
 
 /* ── DOM refs ───────────────────────────────────────────────── */
 const listEl     = document.getElementById('error-list');
@@ -20,6 +25,7 @@ const prevBtn    = document.getElementById('prevBtn');
 const nextBtn    = document.getElementById('nextBtn');
 
 /* ── Render helpers ─────────────────────────────────────────── */
+
 /**
  * Applies the current severity and status filters to a list of
  * already-normalized errors.
@@ -46,7 +52,7 @@ function applyClientFilters(errors) {
 function renderLoading() {
   listEl.innerHTML = `<div class="error-card" style="justify-content:center;gap:12px;">
     <div class="spinner"></div><span>Fetching errors…</span></div>`;
-  if (pagination) {pagination.style.display = 'none';}
+  if (pagination) { pagination.style.display = 'none'; }
 }
 
 /**
@@ -56,7 +62,7 @@ function renderLoading() {
 function renderEmpty() {
   listEl.innerHTML = `<div class="error-card" style="justify-content:center;">
     <span style="color:var(--color-text-muted)">No errors match your filters.</span></div>`;
-  if (pagination) {pagination.style.display = 'none';}
+  if (pagination) { pagination.style.display = 'none'; }
 }
 
 /**
@@ -69,7 +75,7 @@ function renderFetchError(msg) {
     <span style="font-weight:600;color:var(--color-critical)">⚠ Failed to load errors</span>
     <span style="font-size:13px;color:var(--color-text-muted)">${msg}</span>
     <button class="btn btn--outline" onclick="load()" style="margin-top:4px">Try again</button></div>`;
-  if (pagination) {pagination.style.display = 'none';}
+  if (pagination) { pagination.style.display = 'none'; }
 }
 
 /**
@@ -87,14 +93,15 @@ function renderErrors(errors, total) {
     const show = totalPages > 1;
     pagination.style.display = show ? 'flex' : 'none';
     if (show) {
-      if (pageInfo) {pageInfo.textContent = `Page ${state.page} of ${totalPages}`;}
-      if (prevBtn)  {prevBtn.disabled = state.page <= 1;}
-      if (nextBtn)  {nextBtn.disabled = state.page >= totalPages;}
+      if (pageInfo) { pageInfo.textContent = `Page ${state.page} of ${totalPages}`; }
+      if (prevBtn)  { prevBtn.disabled = state.page <= 1; }
+      if (nextBtn)  { nextBtn.disabled = state.page >= totalPages; }
     }
   }
 }
 
 /* ── Load ───────────────────────────────────────────────────── */
+
 /**
  * Fetches and renders the error list for the current filter state.
  *
@@ -102,19 +109,19 @@ function renderErrors(errors, total) {
  *              before filtering, so the card layer always receives the
  *              same shape regardless of data source.
  *
- * Real path  — the API is expected to return an array of raw D1 rows
- *              (or a wrapper with an `errors` / `data` / `items` key).
- *              Each row is passed through normalizeError() before any
- *              client-side filtering or rendering.
+ * Real path  — routes through api.js (apiGet) for centralized auth
+ *              (api_key query param) and error handling (network/4xx/5xx).
+ *              Each raw D1 row is passed through normalizeError() before
+ *              any client-side filtering or rendering.
  *
  * @returns {Promise<void>}
  */
 async function load() {
-  if (state.loading) {return;}
+  if (state.loading) { return; }
   state.loading = true;
   renderLoading();
 
-  // ── MOCK: remove this block when real API is ready ──────────
+  // ── MOCK: set MOCK_ERRORS to [] in constants.js to disable ──
   if (Array.isArray(MOCK_ERRORS) && MOCK_ERRORS.length) {
     await new Promise(r => setTimeout(r, 500));
 
@@ -130,23 +137,30 @@ async function load() {
   }
   // ── END MOCK ─────────────────────────────────────────────────
 
+  // ── Real API via api.js ───────────────────────────────────────
+  const params = {};
+  const sinceIso = sinceToIso(state.since);
+  if (sinceIso) { params.since = sinceIso; }
+  if (state.status && state.status !== 'all') { params.status = state.status; }
+
   try {
-    const res = await fetch(buildUrl(state), { headers: { Accept: 'application/json' } });
-    if (!res.ok) {throw new Error(`HTTP ${res.status} — ${res.statusText}`);}
+    const result = await apiGet('', params);
 
-    const data    = await res.json();
-    const rawRows = Array.isArray(data) ? data : (data.errors ?? data.data ?? data.items ?? []);
+    if (!result.success) {
+      console.error(`[WatchTower] ${result.error.type} error:`, result.error.message);
+      renderFetchError(result.error.message);
+      showToast('Could not fetch errors: ' + result.error.message, true);
+      return;
+    }
 
-    // Normalize every raw D1 row into the shape the card layer expects.
+    // Backend responds with { status: "ok", errors: [...] }
+    const rawRows    = result.data?.errors ?? [];
     const normalized = withResolvedStatuses(rawRows.map(normalizeError));
     const filtered   = applyClientFilters(normalized);
 
     state.total = filtered.length;
     renderErrors(filtered, filtered.length);
-  } catch (err) {
-    console.error('[WatchTower] fetch failed:', err);
-    renderFetchError(err.message);
-    showToast('Could not fetch errors: ' + err.message, true);
+
   } finally {
     state.loading = false;
   }
@@ -156,5 +170,5 @@ async function load() {
 initFilters(state, load);
 load();
 window.addEventListener('pageshow', event => {
-  if (event.persisted) {load();}
+  if (event.persisted) { load(); }
 });

--- a/dashboard/scripts/utils/constants.js
+++ b/dashboard/scripts/utils/constants.js
@@ -1,49 +1,59 @@
 /* ── API ─────────────────────────────────────────────────────── */
-export const API_BASE   = '/api/errors';
-export const PROJECT_ID = 'demo';
+export const API_BASE   = 'https://watchtower-backend.group6.workers.dev/api/errors';
+export const API_KEY    = 'wt_e5432da49ac342e6979f901324dae034';
 export const PAGE_LIMIT = 20;
 
 /**
  * Normalizes a raw D1 error row into the shape the UI expects.
  * Call this on every record coming from the real API.
  *
+ * Real D1 column shapes (confirmed from live API response):
+ *   stack_trace  → plain string (e.g. "TypeError at app.js:42"), NOT a JSON array
+ *   payload_json → JSON string containing message, type, stack_trace, file, lineno, colno
+ *   file         → top-level string column
+ *   lineno       → top-level number column
+ *   colno        → top-level number column
+ *
  * D1 columns  → UI fields
  * ----------    ---------
- * stack_trace_json (JSON string) → stackTrace (string[])
- * payload_json     (JSON string) → deployment, timeline, occurrences, affectedUsers
- * client_timestamp              → firstSeen  (kept as ISO string; format in the card)
- * server_timestamp              → lastSeen   (kept as ISO string; format in the card)
- * error_type                    → errorType
- * (status comes through as-is from D1)
+ * stack_trace  (plain string) → stackTrace
+ * payload_json (JSON string)  → payload (parsed object)
+ * client_timestamp            → firstSeen  (ISO string; format in the card)
+ * server_timestamp            → lastSeen   (ISO string; format in the card)
+ * error_type                  → errorType
+ * status                      → status (comes through as-is from D1)
  *
  * @param {object} row  Raw row from D1 / API response
  * @returns {object}    Normalized error object
  */
 export function normalizeError(row) {
-  let stackTrace = [];
-  let payload    = {};
+  let payload = {};
 
-  try { stackTrace = JSON.parse(row.stack_trace_json ?? '[]'); } catch { /* keep [] */ }
-  try { payload    = JSON.parse(row.payload_json     ?? '{}'); } catch { /* keep {} */ }
+  try { payload = JSON.parse(row.payload_json ?? '{}'); } catch { /* keep {} */ }
 
   return {
     // Core identity
-    id:            row.id,
-    service:       row.service,
-    environment:   row.environment,
-    errorType:     row.error_type  ?? null,
-    severity:      row.severity    ?? 'error',
-    status:        row.status      ?? 'unresolved',
-    message:       row.message,
+    id:          row.id,
+    service:     row.service,
+    environment: row.environment,
+    errorType:   row.error_type  ?? null,
+    severity:    row.severity    ?? 'error',
+    status:      row.status      ?? 'unresolved',
+    message:     row.message,
 
-    // Timestamps (ISO strings from D1 — format these in the card layer)
-    firstSeen:     row.client_timestamp,
-    lastSeen:      row.server_timestamp,
+    // File location (top-level D1 columns)
+    file:   row.file   ?? null,
+    lineno: row.lineno ?? null,
+    colno:  row.colno  ?? null,
 
-    // Stack trace
-    stackTrace,
+    // Stack trace — plain string from D1, not a JSON array
+    stackTrace: row.stack_trace ?? '',
 
-    // Everything else lives in payload_json; provide safe defaults
+    // Timestamps (ISO strings from D1 — format in the card layer)
+    firstSeen: row.client_timestamp,
+    lastSeen:  row.server_timestamp,
+
+    // payload_json fields — safe defaults for fields not yet sent by SDK
     deploy:        payload.deploy         ?? null,
     occurrences:   payload.occurrences    ?? 0,
     affectedUsers: payload.affectedUsers  ?? 0,
@@ -52,138 +62,9 @@ export function normalizeError(row) {
   };
 }
 
-/* ── Mock data ───────────────────────────────────────────────────
+/* ── Mock data ────────────────────────────────────────────────────
  * Shaped to match the real D1 schema so normalizeError() works on
  * both mock and live data without branching.
- * Remove the MOCK_ERRORS export (or set it to []) when the real
- * API is wired up.
+ * Set MOCK_ERRORS to [] to disable and use the real API.
  * ─────────────────────────────────────────────────────────────── */
-export const MOCK_ERRORS = [
-  {
-    id:               '1',
-    api_key:          'demo-key',
-    service:          'api-gateway',
-    environment:      'production',
-    message:          "TypeError: Cannot read property 'user' of undefined",
-    error_type:       'TypeError',
-    severity:         'critical',
-    status:           'unresolved',
-    client_timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
-    server_timestamp: new Date(Date.now() - 4 * 60 * 1000).toISOString(),
-    stack_trace_json: JSON.stringify([
-      'at getUserProfile (app.js:145:12)',
-      'at handleRequest (server.js:89:5)',
-      'at Router.handle (express.js:234:3)',
-      '[... more stack frames ...]',
-    ]),
-    payload_json: JSON.stringify({
-      deploy:        'v2.4.1',
-      occurrences:   847,
-      affectedUsers: 234,
-      deployment: {
-        version:    'v2.4.1',
-        deployedAt: '2 hours ago by john@startup.com',
-        commit:     '#a3f892b',
-      },
-      timeline: [
-        { label: 'Error spike detected',     time: '2 hours ago', type: 'critical' },
-        { label: 'Alert sent to on-call',     time: '2 hours ago', type: 'info'     },
-        { label: 'Deployment v2.4.1 started', time: '2 hours ago', type: 'deploy'   },
-        { label: 'First occurrence recorded', time: '2 hours ago', type: 'info'     },
-      ],
-    }),
-  },
-  {
-    id:               '2',
-    api_key:          'demo-key',
-    service:          'api-gateway',
-    environment:      'production',
-    message:          'Network request failed: timeout after 30000ms',
-    error_type:       'NetworkError',
-    severity:         'high',
-    status:           'unresolved',
-    client_timestamp: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString(),
-    server_timestamp: new Date(Date.now() - 12 * 60 * 1000).toISOString(),
-    stack_trace_json: JSON.stringify([
-      'at XMLHttpRequest.onTimeout (xhr.js:214:8)',
-      'at dispatchXhrRequest (axios.js:178:12)',
-      'at Axios.request (axios.js:225:10)',
-      'at fetchUserData (api.js:67:3)',
-    ]),
-    payload_json: JSON.stringify({
-      deploy:        'v2.4.1',
-      occurrences:   234,
-      affectedUsers: 89,
-      deployment: {
-        version:    'v2.4.1',
-        deployedAt: '5 hours ago by sarah@startup.com',
-        commit:     '#d91c3f4',
-      },
-      timeline: [
-        { label: 'Error spike detected',     time: '5 hours ago', type: 'critical' },
-        { label: 'Alert sent to on-call',     time: '5 hours ago', type: 'info'     },
-        { label: 'First occurrence recorded', time: '5 hours ago', type: 'info'     },
-      ],
-    }),
-  },
-  {
-    id:               '3',
-    api_key:          'demo-key',
-    service:          'web-app',
-    environment:      'production',
-    message:          "React Hook useEffect has a missing dependency: 'userId'",
-    error_type:       'Warning',
-    severity:         'medium',
-    status:           'unresolved',
-    client_timestamp: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
-    server_timestamp: new Date(Date.now() - 3  * 60 * 60 * 1000).toISOString(),
-    stack_trace_json: JSON.stringify([
-      'at checkDepsAreArrayDeps (react-dom.development.js:16302:5)',
-      'at Object.useEffect (react-dom.development.js:16366:7)',
-      'at ProfilePage (ProfilePage.jsx:44:3)',
-    ]),
-    payload_json: JSON.stringify({
-      deploy:        'v2.4.0',
-      occurrences:   89,
-      affectedUsers: 0,
-      deployment: {
-        version:    'v2.4.0',
-        deployedAt: '1 day ago by dev@startup.com',
-        commit:     '#b72e1d9',
-      },
-      timeline: [
-        { label: 'Warning first logged',      time: '1 day ago', type: 'info'   },
-        { label: 'Deployment v2.4.0 started', time: '1 day ago', type: 'deploy' },
-      ],
-    }),
-  },
-  {
-    id:               '4',
-    api_key:          'demo-key',
-    service:          'web-app',
-    environment:      'staging',
-    message:          'Console warning: deprecated API usage — componentWillMount',
-    error_type:       'DeprecationWarning',
-    severity:         'low',
-    status:           'resolved',
-    client_timestamp: new Date(Date.now() - 3  * 24 * 60 * 60 * 1000).toISOString(),
-    server_timestamp: new Date(Date.now() - 1  * 24 * 60 * 60 * 1000).toISOString(),
-    stack_trace_json: JSON.stringify([
-      'at LegacyComponent.componentWillMount (LegacyComponent.jsx:12:5)',
-      'at ReactDOM.render (react-dom.development.js:20558:3)',
-    ]),
-    payload_json: JSON.stringify({
-      deploy:        'v2.3.9',
-      occurrences:   45,
-      affectedUsers: 0,
-      deployment: {
-        version:    'v2.3.9',
-        deployedAt: '3 days ago by dev@startup.com',
-        commit:     '#c44a7e2',
-      },
-      timeline: [
-        { label: 'Deprecation warning logged', time: '3 days ago', type: 'info' },
-      ],
-    }),
-  },
-];
+export const MOCK_ERRORS = [];

--- a/dashboard/tests/api.test.js
+++ b/dashboard/tests/api.test.js
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// ── fetch mock helper ────────────────────────────────────────────
+function mockFetch(status, body, throws = false) {
+  globalThis.fetch = async () => {
+    if (throws) {throw new TypeError('Failed to fetch');}
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    };
+  };
+}
+
+const { apiGet } = await import('../scripts/api/api.js');
+
+// ── Tests ────────────────────────────────────────────────────────
+
+test('apiGet returns success shape on 200', async () => {
+  mockFetch(200, { status: 'ok', errors: [] });
+  const result = await apiGet('', {});
+  assert.equal(result.success, true);
+  assert.deepEqual(result.data, { status: 'ok', errors: [] });
+});
+
+test('apiGet returns network error type when fetch throws', async () => {
+  mockFetch(0, null, true);
+  const result = await apiGet('', {});
+  assert.equal(result.success, false);
+  assert.equal(result.error.type, 'network');
+});
+
+test('apiGet returns client error type on 401', async () => {
+  mockFetch(401, { message: 'Unauthorized' });
+  const result = await apiGet('', {});
+  assert.equal(result.success, false);
+  assert.equal(result.error.type, 'client');
+  assert.equal(result.error.status, 401);
+});
+
+test('apiGet returns client error type on 403', async () => {
+  mockFetch(403, { message: 'Forbidden' });
+  const result = await apiGet('', {});
+  assert.equal(result.success, false);
+  assert.equal(result.error.type, 'client');
+  assert.equal(result.error.status, 403);
+});
+
+test('apiGet returns client error type on 404', async () => {
+  mockFetch(404, { message: 'Not found' });
+  const result = await apiGet('', {});
+  assert.equal(result.success, false);
+  assert.equal(result.error.type, 'client');
+  assert.equal(result.error.status, 404);
+});
+
+test('apiGet returns server error type on 500', async () => {
+  mockFetch(500, { message: 'Internal Server Error' });
+  const result = await apiGet('', {});
+  assert.equal(result.success, false);
+  assert.equal(result.error.type, 'server');
+});
+
+test('apiGet always injects api_key as a query param', async () => {
+  let capturedUrl = '';
+  globalThis.fetch = async (url) => {
+    capturedUrl = url;
+    return { ok: true, status: 200, json: async () => ({}) };
+  };
+  await apiGet('', {});
+  assert.ok(capturedUrl.includes('api_key='), 'api_key must be present in URL');
+});
+
+test('apiGet does not send X-Api-Key header that triggers CORS preflight', async () => {
+  let capturedHeaders = {};
+  globalThis.fetch = async (url, opts) => {
+    capturedHeaders = opts?.headers ?? {};
+    return { ok: true, status: 200, json: async () => ({}) };
+  };
+  await apiGet('', {});
+  const keys = Object.keys(capturedHeaders).map(k => k.toLowerCase());
+  assert.ok(!keys.includes('x-api-key'), 'must not send X-Api-Key header');
+  assert.ok(!keys.includes('authorization'), 'must not send Authorization header');
+});

--- a/dashboard/tests/constants.test.js
+++ b/dashboard/tests/constants.test.js
@@ -1,0 +1,81 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { normalizeError } from '../scripts/utils/constants.js';
+
+const RAW_ROW = {
+  id: 'abc-123',
+  service: 'my-app',
+  environment: 'production',
+  message: 'TypeError crashed',
+  error_type: 'TypeError',
+  severity: 'error',
+  stack_trace: 'TypeError at app.js:42',
+  payload_json: JSON.stringify({ deploy: 'v1.2', occurrences: 5 }),
+  client_timestamp: '2026-05-16T10:00:00.000Z',
+  server_timestamp: '2026-05-16T10:00:01.000Z',
+  status: 'unresolved',
+  file: 'app.js',
+  lineno: 42,
+  colno: 15,
+};
+
+test('normalizeError maps id correctly', () => {
+  assert.equal(normalizeError(RAW_ROW).id, 'abc-123');
+});
+
+test('normalizeError maps service and environment', () => {
+  const n = normalizeError(RAW_ROW);
+  assert.equal(n.service, 'my-app');
+  assert.equal(n.environment, 'production');
+});
+
+test('normalizeError maps message and errorType', () => {
+  const n = normalizeError(RAW_ROW);
+  assert.equal(n.message, 'TypeError crashed');
+  assert.equal(n.errorType, 'TypeError');
+});
+
+test('normalizeError maps stack_trace plain string to stackTrace', () => {
+  const n = normalizeError(RAW_ROW);
+  assert.equal(typeof n.stackTrace, 'string');
+  assert.equal(n.stackTrace, 'TypeError at app.js:42');
+});
+
+test('normalizeError maps client_timestamp to firstSeen', () => {
+  assert.equal(normalizeError(RAW_ROW).firstSeen, '2026-05-16T10:00:00.000Z');
+});
+
+test('normalizeError maps server_timestamp to lastSeen', () => {
+  assert.equal(normalizeError(RAW_ROW).lastSeen, '2026-05-16T10:00:01.000Z');
+});
+
+test('normalizeError maps file, lineno, colno from top-level D1 columns', () => {
+  const n = normalizeError(RAW_ROW);
+  assert.equal(n.file, 'app.js');
+  assert.equal(n.lineno, 42);
+  assert.equal(n.colno, 15);
+});
+
+test('normalizeError parses payload_json and extracts known fields', () => {
+  const n = normalizeError(RAW_ROW);
+  assert.equal(n.deploy, 'v1.2');
+  assert.equal(n.occurrences, 5);
+});
+
+test('normalizeError falls back to empty defaults on invalid payload_json', () => {
+  const n = normalizeError({ ...RAW_ROW, payload_json: 'not-json' });
+  assert.equal(n.occurrences, 0);
+  assert.equal(n.affectedUsers, 0);
+});
+
+test('normalizeError preserves status column value', () => {
+  assert.equal(normalizeError(RAW_ROW).status, 'unresolved');
+});
+
+test('normalizeError handles missing optional fields with safe defaults', () => {
+  const n = normalizeError({ id: '1', message: 'oops' });
+  assert.equal(n.stackTrace, '');
+  assert.equal(n.occurrences, 0);
+  assert.equal(n.affectedUsers, 0);
+});

--- a/dashboard/tests/errorFilter.test.js
+++ b/dashboard/tests/errorFilter.test.js
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { sinceToIso } from '../scripts/pages/errorList/errorFilter.js';
+
+test('sinceToIso returns null for "all"', () => {
+  assert.equal(sinceToIso('all'), null);
+});
+
+test('sinceToIso returns null for unknown shorthand', () => {
+  assert.equal(sinceToIso('forever'), null);
+});
+
+test('sinceToIso returns a valid ISO string for "24h"', () => {
+  const result = sinceToIso('24h');
+  assert.ok(result !== null, 'should not be null');
+  assert.ok(!isNaN(Date.parse(result)), 'should be a valid ISO string');
+});
+
+test('sinceToIso "24h" produces a timestamp approximately 24 hours ago', () => {
+  const result = sinceToIso('24h');
+  const diff = Date.now() - Date.parse(result);
+  assert.ok(diff >= 23 * 60 * 60 * 1000, 'should be at least 23h ago');
+  assert.ok(diff <= 25 * 60 * 60 * 1000, 'should be at most 25h ago');
+});
+
+test('sinceToIso returns a valid ISO string for "7d"', () => {
+  const result = sinceToIso('7d');
+  assert.ok(!isNaN(Date.parse(result)), 'should be a valid ISO string');
+});
+
+test('sinceToIso "7d" produces a timestamp approximately 7 days ago', () => {
+  const result = sinceToIso('7d');
+  const diff = Date.now() - Date.parse(result);
+  assert.ok(diff >= 6.9 * 24 * 60 * 60 * 1000, 'should be at least ~7 days ago');
+  assert.ok(diff <= 7.1 * 24 * 60 * 60 * 1000, 'should be at most ~7 days ago');
+});
+
+test('sinceToIso returns a valid ISO string for "30d"', () => {
+  const result = sinceToIso('30d');
+  assert.ok(!isNaN(Date.parse(result)), 'should be a valid ISO string');
+});
+
+test('sinceToIso "30d" produces a timestamp approximately 30 days ago', () => {
+  const result = sinceToIso('30d');
+  const diff = Date.now() - Date.parse(result);
+  assert.ok(diff >= 29 * 24 * 60 * 60 * 1000, 'should be at least ~30 days ago');
+  assert.ok(diff <= 31 * 24 * 60 * 60 * 1000, 'should be at most ~31 days ago');
+});

--- a/e2e/errorDetail.spec.js
+++ b/e2e/errorDetail.spec.js
@@ -1,0 +1,104 @@
+/**
+ * errorDetail.spec.js — Playwright tests for error-detail.html
+ */
+
+import { test, expect } from '@playwright/test';
+
+// Real ID from confirmed live data
+const REAL_ID = 'a32f9624-0574-44a7-b236-9ac27025d515';
+
+test.describe('Error Detail page', () => {
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        'watchtower:session',
+        JSON.stringify({ email: 'test@ucsd.edu' })
+      );
+    });
+  });
+
+  test('page loads without JS errors', async ({ page }) => {
+    const errors = [];
+    page.on('pageerror', err => errors.push(err.message));
+    await page.goto(`/error-detail.html?id=${REAL_ID}`);
+    await page.waitForLoadState('networkidle');
+    expect(errors).toHaveLength(0);
+  });
+
+  test('renders navbar', async ({ page }) => {
+    await page.goto(`/error-detail.html?id=${REAL_ID}`);
+    await expect(page.locator('#navbar-root')).not.toBeEmpty();
+  });
+
+  test('renders detail card with message', async ({ page }) => {
+    await page.goto(`/error-detail.html?id=${REAL_ID}`);
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('.detail-card')).toBeVisible();
+    await expect(page.locator('.detail-card__message')).not.toBeEmpty();
+  });
+
+  test('renders severity badge', async ({ page }) => {
+    await page.goto(`/error-detail.html?id=${REAL_ID}`);
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('.badge')).toBeVisible();
+  });
+
+  test('renders stats cards', async ({ page }) => {
+    await page.goto(`/error-detail.html?id=${REAL_ID}`);
+    await page.waitForLoadState('networkidle');
+    const stats = page.locator('.detail-stat');
+    await expect(stats).toHaveCount(4);
+  });
+
+  test('renders stack trace section when stackTrace is present', async ({ page }) => {
+    await page.goto(`/error-detail.html?id=${REAL_ID}`);
+    await page.waitForLoadState('networkidle');
+    const stack = page.locator('.stack-trace');
+    const count = await stack.count();
+    if (count > 0) {
+      await expect(stack).toBeVisible();
+    }
+  });
+
+  test('resolve button is present and labeled correctly', async ({ page }) => {
+    await page.goto(`/error-detail.html?id=${REAL_ID}`);
+    await page.waitForLoadState('networkidle');
+    const btn = page.locator('#resolve-btn');
+    await expect(btn).toBeVisible();
+    await expect(btn).toHaveText(/Mark Resolved|✓ Resolved/);
+  });
+
+  test('back link navigates to error-list.html', async ({ page }) => {
+    await page.goto(`/error-detail.html?id=${REAL_ID}`);
+    await page.locator('#back-link').click();
+    await expect(page).toHaveURL(/error-list\.html/);
+  });
+
+  test('no ID in URL renders error state', async ({ page }) => {
+    await page.goto('/error-detail.html');
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('#detail-root')).toContainText('No error ID specified');
+  });
+
+  test('invalid ID renders error state', async ({ page }) => {
+    await page.goto('/error-detail.html?id=does-not-exist');
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('#detail-root')).toContainText('Could not load error');
+  });
+
+  test('document title updates with error severity and message', async ({ page }) => {
+    await page.goto(`/error-detail.html?id=${REAL_ID}`);
+    await page.waitForLoadState('networkidle');
+    const title = await page.title();
+    expect(title).toMatch(/WatchTower/);
+    expect(title).not.toBe('Error Detail'); // default title should be overwritten
+  });
+
+  test('redirects to login when no session', async ({ page }) => {
+    // No session injected — requireAuth() should redirect
+    await page.goto(`/error-detail.html?id=${REAL_ID}`);
+    await expect(page).toHaveURL(/login\.html/);
+  });
+
+});

--- a/e2e/errorDetail.spec.js
+++ b/e2e/errorDetail.spec.js
@@ -11,11 +11,21 @@ test.describe('Error Detail page', () => {
 
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
+      // eslint-disable-next-line no-undef
       localStorage.setItem(
         'watchtower:session',
         JSON.stringify({ email: 'test@ucsd.edu' })
       );
     });
+  });
+
+  test('redirects to login when no session', async ({ page }) => {
+    await page.addInitScript(() => {
+      // eslint-disable-next-line no-undef
+      localStorage.removeItem('watchtower:session');
+    });
+    await page.goto(`/error-detail.html?id=${REAL_ID}`);
+    await expect(page).toHaveURL(/login\.html/);
   });
 
   test('page loads without JS errors', async ({ page }) => {
@@ -92,13 +102,7 @@ test.describe('Error Detail page', () => {
     await page.waitForLoadState('networkidle');
     const title = await page.title();
     expect(title).toMatch(/WatchTower/);
-    expect(title).not.toBe('Error Detail'); // default title should be overwritten
-  });
-
-  test('redirects to login when no session', async ({ page }) => {
-    // No session injected — requireAuth() should redirect
-    await page.goto(`/error-detail.html?id=${REAL_ID}`);
-    await expect(page).toHaveURL(/login\.html/);
+    expect(title).not.toBe('Error Detail');
   });
 
 });


### PR DESCRIPTION
# Info

Closes #74. (If there is no issue for this pull request yet, please create one or
delete this line if the pull request is for a very minor tweak).

# Description

What changes did you make? List all distinct problems that this PR addresses. Explain any relevant
motivation or context.

### api.js
- Created centralized fetch wrapper. Only public export is apiGet(endpoint, params)
- Auth via api_key as query param (not header): CORS
  access-control-allow-headers: Content-Type only blocks custom headers
- Three normalized error states: network, client, server
- Discriminated return shape: { success, data } or { success, error }
- Only Accept: application/json and Content-Type: application/json headers,
  nothing that triggers CORS preflight

### constants.js
- Added API_BASE, API_KEY, PAGE_LIMIT
- Removed PROJECT_ID, no project_id column in D1
- MOCK_ERRORS = [], real API active by default, mock restoreable without
  touching logic files
- Added normalizeError(), maps raw D1 rows to UI shape
  - stackTrace mapped from plain string stack_trace, not JSON array
  - file, lineno, colno mapped from top level D1 columns
  - payload_json parsed safely with try/catch fallback to {}
  - firstSeen from client_timestamp, lastSeen from server_timestamp

### errorFilter.js
- Added api_key injected into every buildUrl() request
- Removed projectId, no project_id column in D1
- Added sinceToIso(), converts "24h"/"7d"/"30d" to ISO 8601 for
  backend since param
- Fixed buildUrl() return value, was returning query string only,
  now returns full URL
- Commented out severity filter, all real records currently come back
  as "error"

### errorList.js
- Replaced raw fetch() with apiGet() from api.js
- Added requireAuth() page guard
- Added withResolvedStatuses() applied to both mock and real paths
- Removed buildUrl import, added static sinceToIso import from
  errorFilter.js
- Added normalizeError() to both mock and real paths before render
- Added window.load = load, fixes onclick="load()" broken in
  ES module scope
- Tightened response extraction to result.data?.errors ?? []
- Added try/finally to guarantee state.loading = false resets
- Added pageshow listener for back/forward cache re-fetch
- Changed default since from 24h to 30d. Surfaces existing
  test data in dev environment

### error-list.html
- Added missing pagination elements, #pagination, #prevBtn,
  #nextBtn, #pageInfo
- Fixed selectg typo on 30d option. Was invalid HTML attribute,
  browser silently ignored it causing UI and JS state to be out of sync
- Changed 30d option to selected to match state.since = '30d' in JS

### errorDetail.js
- Replaced raw fetch() GET with apiGet() from api.js so all GET
  requests route through the centralized API client (DASH-3)
- Added workaround for missing backend /api/errors/:id route:
  fetches full list via apiGet('', { status: 'all' }) and finds
  the matching record by id client-side
- Fixed renderStackTrace() receiving a plain string, wrapped
  err.stackTrace in an array before passing to renderStackTrace()
  which explicitly expects string[]
- Fixed duplicate fetchError() declaration introduced during iterative
  fixes, ES modules are strict mode, duplicate declarations throw
  a SyntaxError
- Fixed duplicate MOCK_ERRORS import introduced during iterative fixes
- Removed dead commented-out code (old /api/errors/:id path)

### error-detail.html
- Replaced file which was an exact copy of error-list.html with the
  correct page containing detail-root, resolve-btn, navbar-root,
  toast mount points and the errorDetail.js script tag

### tests/api.test.js (new file)
- Added unit tests for apiGet() covering success shape on 200,
  network error type when fetch throws, client error type on 401/403/404,
  server error type on 500, api_key query param always injected, and
  absence of CORS-triggering headers (X-Api-Key, Authorization)
- Uses globalThis.fetch override to mock network responses without
  any external dependencies

### tests/constants.test.js (new file)
- Added unit tests for normalizeError() covering id, service,
  environment, message, errorType, stackTrace as plain string, firstSeen
  from client_timestamp, lastSeen from server_timestamp, file/lineno/colno
  from top-level D1 columns, payload_json parsing, invalid payload_json
  fallback to safe defaults, status preservation, and missing optional
  field defaults

### tests/errorFilter.test.js (new file)
- Added unit tests for sinceToIso() covering null return for "all"
  and unknown shorthands, valid ISO string output for 24h/7d/30d,
  and approximate timestamp accuracy for each shorthand

### e2e/errorList.spec.js (new file)
- Added Playwright tests for error-list.html covering page load
  without JS errors, navbar render, filter dropdowns present, 30d
  default selection, error cards or empty state rendered, pagination
  DOM elements present, card click navigates to error-detail.html,
  and filter change does not crash the page

### e2e/errorDetail.spec.js (new file)
- Added Playwright tests for error-detail.html covering page load
  without JS errors, navbar render, detail card with message, severity
  badge, four stats cards, stack trace section when present, resolve
  button label, back link navigates to error-list.html, no-ID error
  state, invalid-ID error state, document title update, and auth
  redirect when no session exists

### Problems addressed

1. No centralized API client, all files called raw fetch() directly
   with hardcoded URLs and no consistent error handling. api.js introduced
   as the single point of contact for all GET requests per DASH-3.

2. CORS blocked custom auth headers, backend access-control-allow-headers
   only allows Content-Type. Moved api_key to query param to avoid
   preflight rejection.

3. Error list showed no data, default since: '24h' filtered out all
   5 test records which were 3 days old. Changed default to 30d.

4. Detail page showed "Resource not found". Backend has no
   /api/errors/:id route. Workaround fetches full list and filters
   client-side with no backend changes required.

5. Stack trace rendered garbage, renderStackTrace() calls .map()
   and expects string[] but received a plain string, causing it to
   iterate character by character.

6. onclick="load()" broken, ES modules do not attach exports to
   window automatically. Added window.load = load.

7. Pagination broke silently, four DOM IDs referenced in errorList.js
   did not exist in error-list.html.

8. error-detail.html was wrong file, was an exact copy of
   error-list.html, loading errorList.js and missing all DOM elements
   the detail page depends on.

9. Duplicate fetchError() declaration caused a SyntaxError in
   strict mode, silently breaking the entire module.

10. No test coverage for apiGet(), the core DASH-3 deliverable
    had zero tests. All success, failure, and CORS safety behaviours
    are now covered.

11. No test coverage for normalizeError(), field mapping from
    raw D1 rows to UI shape was entirely untested, including the
    plain string stack_trace edge case and invalid payload_json
    fallback.

12. No test coverage for sinceToIso(), time filter conversion
    from shorthand to ISO 8601 was untested. Incorrect output here
    causes the backend to return zero records silently.

13. No render-layer tests for the error list page, pagination
    DOM presence, default filter value, and card click navigation
    were all unverified.

14. No render-layer tests for the error detail page, the detail
    page had the most bugs of any file worked on. Tests now cover
    all critical render paths including the no-ID and invalid-ID
    error states and the auth redirect guard.

## Changes

Created (new files):

    scripts/api/api.js
    tests/api.test.js
    tests/constants.test.js
    tests/errorFilter.test.js
    e2e/errorList.spec.js
    e2e/errorDetail.spec.js

Modified (existing files):

    scripts/utils/constants.js
    scripts/pages/errorList/errorFilter.js
    scripts/pages/errorList/errorList.js
    scripts/pages/errorDetail/errorDetail.js
    error-list.html
    error-detail.html

## AI Use Log

TritonGPT Claude Sonnet 4.6

# Type of Change

- [ ] Patch (non-breaking change/bugfix)
- [ ] Minor (non-breaking change which adds functionality)
- [x] Major (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (A change to a README/description/docs)
- [ ] Continuous Integration/DevOps Change (Related to deployment steps, continuous integration
      workflows, linting, etc.)
- [ ] Other: (Fill In)

If you've selected Patch, Minor, or Major as your change type, **make sure to bump the version before merging in `package.json`!**

# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally.
- [ ] on the testing API/testing database.

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [x] My changes produce no new warnings.

# Definition of Done(DoD): you have checked that

- [x] Code works and is committed
- [x] Tests added (unit and/or E2E as appropriate) and passing
- [ ] JSDoc on any new public surfaces
- [x] Linting passes locally and in CI
- [ ] Docs updated (README, Wiki, this primer if relevant)
- [x] Commit messages follow Conventional Commits
- [x] PR description discloses any AI usage
- [x] If >300 LoC: reviewed by another human team member
- [x] Issue moved to Done on the project board

# Screenshots

<img width="864" height="482" alt="image"
src="https://github.com/user-attachments/assets/56025356-bbe1-402a-8bdc-30a1fdc6e1d0" />
<img width="1562" height="1648" alt="image" src="https://github.com/user-attachments/assets/ce2082d7-d945-4483-8e33-de1ad80ed9a7" />

```