### PR TITLE
feat(backend): add performance ingestion and read endpoint

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -57,3 +57,28 @@ CREATE TABLE IF NOT EXISTS users (
 
 CREATE INDEX IF NOT EXISTS idx_projects_owner
 ON projects (owner_id);
+
+-- This is the performance talbe which stores the performance info according to sdk schema
+CREATE TABLE IF NOT EXISTS performance (
+    id TEXT PRIMARY KEY,
+    api_key TEXT NOT NULL,
+    service TEXT NOT NULL,
+    environment TEXT NOT NULL,
+    name TEXT NOT NULL,
+    entry_type TEXT NOT NULL,
+    time REAL NOT NULL,
+    duration REAL NOT NULL,
+    payload_json TEXT NOT NULL,
+    client_timestamp TEXT NOT NULL,
+    server_timestamp TEXT NOT NULL,
+    FOREIGN KEY (api_key) REFERENCES projects(api_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_performance_api_key
+ON performance (api_key);
+
+CREATE INDEX IF NOT EXISTS idx_performance_entry_type
+ON performance (entry_type);
+
+CREATE INDEX IF NOT EXISTS idx_performance_server_timestamp
+ON performance (server_timestamp);

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -2,6 +2,7 @@ import { handleIngest } from "./routes/ingest.js";
 import { generateApiKey, createUser, getUserById } from './middleware/auth.js';
 import { handleGetErrors, handleGetErrorById, handleResolveError } from './routes/errors.js';
 import { handleListProjects } from './routes/projects.js';
+import { handleGetPerformance } from './routes/performance.js';
 
 export default {
   async fetch(request, env) {
@@ -102,7 +103,9 @@ export default {
     if (path === '/api/errors' && request.method === 'GET') {
       return handleGetErrors(request, env);
     }
-
+    if (path === '/api/performance' && request.method === 'GET') {
+      return handleGetPerformance(request, env);
+    }
     return jsonResponse({ status: "error", message: "Not found" }, 404);
   },
 };

--- a/backend/src/routes/ingest.js
+++ b/backend/src/routes/ingest.js
@@ -1,13 +1,12 @@
 import { jsonResponse } from '../index.js'; // imported function which is convenient for consistent response return
-import { storeError } from '../storage/d1.js'; // imported function from d1, link to d1.js
 import { validateApiKey } from '../middleware/auth.js';
-
+import { storeError, storePerformance } from '../storage/d1.js'; // import functions from storage and link with it
 const VALID_ENDPOINTS = ['/ingest/error', '/ingest/log', '/ingest/performance'];
 const REQUIRED_PAYLOAD_FIELDS = {
   // added all properties in event except for severity, will add it after sdk implements it
   '/ingest/error': ['message', 'type', 'stack_trace', 'file', 'lineno', 'colno'],
   '/ingest/log': ['message', 'level', 'timestamp'],
-  '/ingest/performance': ['name', 'start_timestamp', 'end_timestamp', 'duration_ms'],
+  '/ingest/performance': ['name', 'entryType', 'time', 'duration'],
 };
 
 // Hardcoded keys for now — BE-4 replaces with D1 lookup
@@ -88,6 +87,21 @@ export async function handleIngest(request, env, path) {
         };
         // we send this bounded data to
         await storeError(env, record);
+      } else if (path === '/ingest/performance') {
+        const record = {
+          id: crypto.randomUUID(),
+          api_key: data.api_key,
+          service: data.service,
+          environment: data.environment,
+          name: event.payload.name,
+          entry_type: event.payload.entryType,
+          time: event.payload.time,
+          duration: event.payload.duration,
+          payload_json: JSON.stringify(event.payload),
+          client_timestamp: event.timestamp,
+          server_timestamp,
+        };
+        await storePerformance(env, record);
       }
       // storeLog and storePerformance added once Ethan adds tables
     } catch (err) {

--- a/backend/src/routes/performance.js
+++ b/backend/src/routes/performance.js
@@ -1,0 +1,50 @@
+/* global console */
+/**
+ * routes/performance.js
+ * Handles read API requests for performance data.
+ *
+ * Current endpoints:
+ *   GET /api/performance — returns paginated performance events for a project
+ */
+import { jsonResponse } from '../index.js';
+import { getPerformance } from '../storage/d1.js';
+import { validateApiKey } from '../middleware/auth.js';
+
+/**
+ * Handles GET /api/performance
+ * Returns performance events for a project
+ *
+ * Query parameters:
+ *   api_key    — required
+ *   entry_type — filter by resource/paint/navigation
+ *   since      — ISO timestamp
+ *   page       — defaults to 1
+ *   limit      — defaults to 20
+ *
+ * @param {Request} request
+ * @param {object} env
+ */
+export async function handleGetPerformance(request, env) {
+  const url = new URL(request.url);
+  const api_key = url.searchParams.get('api_key');
+
+  const project = await validateApiKey(env, api_key);
+  if (!project) {
+    return jsonResponse({ status: 'error', message: 'Invalid API key' }, 401);
+  }
+
+  const queryParams = {
+    entry_type: url.searchParams.get('entry_type'),
+    since:      url.searchParams.get('since'),
+    page:       parseInt(url.searchParams.get('page')  ?? '1'),
+    limit:      parseInt(url.searchParams.get('limit') ?? '20'),
+  };
+
+  try {
+    const events = await getPerformance(env, api_key, queryParams);
+    return jsonResponse({ status: 'ok', performance: events }, 200);
+  } catch (err) {
+    console.error('Failed to fetch performance:', err);
+    return jsonResponse({ status: 'error', message: 'Failed to fetch performance' }, 500);
+  }
+}

--- a/backend/src/routes/performance.js
+++ b/backend/src/routes/performance.js
@@ -1,4 +1,3 @@
-/* global console */
 /**
  * routes/performance.js
  * Handles read API requests for performance data.

--- a/backend/src/storage/d1.js
+++ b/backend/src/storage/d1.js
@@ -121,3 +121,61 @@ export async function listProjectsByOwner(env, owner_id) {
 
   return result.results;
 }
+
+/**
+ * Stores a performance event in D1
+ * @param {object} env - Cloudflare env with D1 binding
+ * @param {object} record - fully prepared record from ingest.js
+ */
+export async function storePerformance(env, record) {
+  await env.watchtower_db.prepare(`
+    INSERT INTO performance (id, api_key, service, environment, name, entry_type, time, duration, payload_json, client_timestamp, server_timestamp)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).bind(
+    record.id,
+    record.api_key,
+    record.service,
+    record.environment,
+    record.name,
+    record.entry_type,
+    record.time,
+    record.duration,
+    record.payload_json,
+    record.client_timestamp,
+    record.server_timestamp
+  ).run();
+}
+
+/**
+ * Reads performance events from D1 for a given project
+ * @param {object} env - Cloudflare env with D1 binding
+ * @param {string} api_key - project api key
+ * @param {object} params - optional filters
+ * @param {string} [params.entry_type] - filter by resource/paint/navigation
+ * @param {string} [params.since] - ISO timestamp
+ * @param {number} [params.page=1]
+ * @param {number} [params.limit=20]
+ * @returns {object[]}
+ */
+export async function getPerformance(env, api_key, params = {}) {
+  const { entry_type, since, page = 1, limit = 20 } = params;
+  const offset = (page - 1) * limit;
+
+  let query = 'SELECT * FROM performance WHERE api_key = ?';
+  const bindings = [api_key];
+
+  if (entry_type && entry_type !== 'all') {
+    query += ' AND entry_type = ?';
+    bindings.push(entry_type);
+  }
+  if (since) {
+    query += ' AND server_timestamp >= ?';
+    bindings.push(since);
+  }
+
+  query += ' ORDER BY server_timestamp DESC LIMIT ? OFFSET ?';
+  bindings.push(limit, offset);
+
+  const result = await env.watchtower_db.prepare(query).bind(...bindings).run();
+  return result.results;
+}


### PR DESCRIPTION
# Info

Closes #[issue number]. (If there is no issue for this pull request yet, please create one or
delete this line if the pull request is for a very minor tweak).

# Description

Performance ingestion and read endpoints are now there

## Changes

changes on d1.js, sql, index.js, injest.js. added performance.js 

## AI Use Log

Did you use AI to generate code? List all tools and prompts used, and files changed as a result. If not, write "N/A".

# Type of Change

- [x] Patch (non-breaking change/bugfix)
- [ ] Minor (non-breaking change which adds functionality)
- [x] Major (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (A change to a README/description/docs)
- [ ] Continuous Integration/DevOps Change (Related to deployment steps, continuous integration
      workflows, linting, etc.)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

If you've selected Patch, Minor, or Major as your change type, **make sure to bump the version before merging in `package.json`!**
# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally.
- [x] on the testing API/testing database.

# Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have followed the style guidelines of this project.
- [ ] My changes produce no new warnings.

# Definition of Done(DoD): you have checked that

- [x] Code works and is committed
- [] Tests added (unit and/or E2E as appropriate) and passing
- [ ] JSDoc on any new public surfaces
- [ ] Linting passes locally and in CI
- [ ] Docs updated (README, Wiki, this primer if relevant)
- [ ] Commit messages follow Conventional Commits
- [ ] PR description discloses any AI usage
- [ ] If >300 LoC: reviewed by another human team member
- [ ] Issue moved to Done on the project board

# Screenshots

Please include screenshots of any relevant changes, if applicable.
